### PR TITLE
Force BepInEx.IL2CPP v6.0.0-be.401 for compatibility

### DIFF
--- a/autotracker/FF4PRAutotracker.csproj
+++ b/autotracker/FF4PRAutotracker.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BepInEx.IL2CPP" Version="6.0.0-*" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.IL2CPP" Version="6.0.0-be.401" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="7.0.3" />
     <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />


### PR DESCRIPTION
Falcon Dive ships an older version of BepInEx (pre be.577) which can't load plugins compiled against more current versions.